### PR TITLE
Online list

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Variables available for service configuration (see [config.js](/config.js)):
  * `REDIS_NOTIFICATIONS_PORT_6379_TCP_ADDR` — Redis notifications host
  * `REDIS_NOTIFICATIONS_PORT_6379_TCP_PORT` — Redis notifications port
  * `MESSAGE_QUEUE_SIZE` — Redis notifications queue size
+ * `ONLINE_LIST_SIZE` — Redis list size with users most recently online
  * `API_SECRET` — Secret passcode required to send notifications
 
 AuthDB
@@ -112,4 +113,22 @@ If secret is invalid.
 ### design note
 
 The value of "secret" should be equal to the `API_SECRET` environment variable.
+
+# Online User List [/notifications/v1/online]
+
+Every time client sends request for retrieving messages for a particular user, that user is added to a top of the list of recently online users in Redis.
+
+List is trimmed at `ONLINE_LIST_SIZE` most recent users.
+
+## Retrive List [GET]
+
+Will return a list of usernames of most recently online users. This list is publicly available (no `API_SECRET` or auth required).
+
+### response [200] OK
+
+    [ "username",
+      "alice",
+      ...
+      "bob"
+    ]
 

--- a/config.js
+++ b/config.js
@@ -14,6 +14,7 @@ module.exports = {
     host: process.env.REDIS_NOTIFICATIONS_PORT_6379_TCP_ADDR || 'localhost',
     port: +process.env.REDIS_NOTIFICATIONS_PORT_6379_TCP_PORT || 6379,
     queueSize: +process.env.MESSAGE_QUEUE_SIZE || 50,
+    onlineSize: +process.env.ONLINE_LIST_SIZE || 20,
     channel: 'post'
   }
 };

--- a/src/notifications-api/index.coffee
+++ b/src/notifications-api/index.coffee
@@ -6,6 +6,7 @@ config = require '../../config'
 PubSub = require './pubsub'
 Queue = require './queue'
 LongPoll = require './long-poll'
+OnlineList = require './online-list'
 
 sendError = (err, next) ->
   log.error err
@@ -23,8 +24,10 @@ notificationsApi = (options={}) ->
 
   # notificatinos redis pub/sub
   # notifications redis queue
+  # list of users recently online
   pubsub = options.pubsub
   queue = options.queue
+  onlineList = options.onlineList
 
   do () ->
     client = redis.createClient(config.redis.port, config.redis.host)
@@ -37,6 +40,9 @@ notificationsApi = (options={}) ->
 
     if !queue
       queue = new Queue(client, {maxSize: config.redis.queueSize})
+
+    if !onlineList
+      onlineList = new OnlineList(client, {maxSize: config.redis.onlineSize})
 
   # notify the listeners of incoming messages
   # called when new data is available for a user
@@ -96,6 +102,11 @@ notificationsApi = (options={}) ->
       () ->
         res.json([])
 
+  # Adds user performing request to the top of Recently Online Users list.
+  onlineListMiddleware = (req, res, next) ->
+    onlineList.add req.params.user.username, (err) ->
+    next()
+
   #
   # Endpoints
   #
@@ -146,10 +157,20 @@ notificationsApi = (options={}) ->
       res.json(reply)
       next()
 
+  # Return list of usernames most recently online
+  onlineListEndpoint = (req, res, next) ->
+    onlineList.get (err, list) ->
+      if (err)
+        return sendError(new restify.InternalServerError(), next)
+
+      res.json(list)
+      next()
+
   return (prefix, server) ->
     server.get "/#{prefix}/auth/:authToken/messages",
-      authMiddleware, getMessages, longPollMiddleware
+      authMiddleware, onlineListMiddleware, getMessages, longPollMiddleware
     server.post "/#{prefix}/messages", apiSecretMiddleware, postMessage
+    server.get "/#{prefix}/online", onlineListEndpoint
 
 module.exports = notificationsApi
 

--- a/src/notifications-api/online-list.coffee
+++ b/src/notifications-api/online-list.coffee
@@ -1,0 +1,37 @@
+log = require '../log'
+
+class OnlineList
+  constructor: (redis, options={}) ->
+    @redis = redis
+    @maxRedisIndex = options.maxSize - 1
+    @key = options.key || 'online-list'
+
+    if !@redis
+      throw new Error('OnlineList() requires a Redis client')
+
+    if !isFinite(@maxRedisIndex) || (@maxRedisIndex < 0)
+      throw new Error('OnlineList() requires options.maxSize to be Integer > 0')
+
+  _add: (username, callback) ->
+    @redis.multi()
+      .lpush(@key, username)
+      .ltrim(@key, 0, @maxRedisIndex)
+      .exec(callback)
+
+  add: (username, callback) ->
+    @_add username, (err, replies) ->
+      if (err)
+        log.error 'OnlineList failed to add user',
+          err: err
+          replies: replies
+
+      callback(err)
+
+  get: (callback) ->
+    @redis.lrange @key, 0, -1, (err, list) ->
+      if (err)
+        log.error 'OnlineList failed to retrieve list', {err: err}
+
+      callback(err, list)
+
+module.exports = OnlineList

--- a/tests/notifications-api/test-online-list.coffee
+++ b/tests/notifications-api/test-online-list.coffee
@@ -1,0 +1,71 @@
+vasync = require 'vasync'
+expect = require 'expect.js'
+fakeRedis = require 'fakeredis'
+OnlineList = require '../../src/notifications-api/online-list'
+
+TEST_LIST = ['alice', 'bob', 'jdoe']
+TEST_MAX_SIZE = TEST_LIST.length
+
+clone = (obj) -> JSON.parse(JSON.stringify(obj))
+
+reverseArray = (arr) ->
+  copy = clone(arr)
+  reversed = []
+
+  for item in copy
+    reversed.unshift(item)
+
+  return reversed
+
+describe 'OnlineList', () ->
+  redisClient = fakeRedis.createClient(__filename)
+  list = new OnlineList(redisClient, {maxSize: TEST_MAX_SIZE})
+
+  before (cb) ->
+    redisClient.flushdb(cb)
+
+  # Adding users 1 by 1 in order defined in TEST_LIST
+  # (resulting online list is reversed).
+  initList = (callback) ->
+    vasync.forEachPipeline
+      func: list.add.bind(list)
+      inputs: TEST_LIST
+      , callback
+
+  getList = (callback) ->
+    list.get(callback)
+
+  it 'adds users to the top of the list', (done) ->
+    initList (err) ->
+      expect(err).to.be(null)
+
+      # Since most recent users go to the top of the list,
+      # we expect to get reversed copy of TEST_LIST.
+      getList (err, list) ->
+        expect(err).to.be(null)
+        expect(list).to.eql(reverseArray(TEST_LIST))
+        done()
+
+  it 'trims list at options.maxSize usernames', (done) ->
+    username = 'alice-will-get-trimmed'
+    expected = reverseArray(TEST_LIST)          # initial (from #add() test)
+    expected.unshift(username)                  # add new username
+    expected = expected.slice(0, TEST_MAX_SIZE) # trim to max size
+
+    list.add username, (err) ->
+      expect(err).to.be(null)
+
+      getList (err, list) ->
+        expect(err).to.be(null)
+        expect(list).to.eql(expected)
+        done()
+
+  it 'retrives list', (done) ->
+    getList (err, wrappedList) ->
+      expect(err).to.be(null)
+
+      redisClient.lrange list.key, 0, -1, (err, rawList) ->
+        expect(err).to.be(null)
+        expect(wrappedList).to.have.length(TEST_MAX_SIZE)
+        expect(wrappedList).to.eql(rawList)
+        done()


### PR DESCRIPTION
Maintains a list of Users who recently had been online.

When the client asks for notifications for user, we add him to the top of this list. Stored as redis' Ordered Set (sorted by `-timestamp` of request); set is capped at `config.options.onlineSize`, most recent requests are at the top of the list.

List is publicly available via `GET /{prefix}/online`.
