### PR TITLE
Push API Fixes

### DIFF
--- a/config.js
+++ b/config.js
@@ -36,16 +36,25 @@ module.exports = {
   },
 
   pushApi: {
+    // Redis and its queues
     redisHost: process.env.REDIS_PUSHAPI_PORT_6379_TCP_ADDR || 'localhost',
     redisPort: +process.env.REDIS_PUSHAPI_PORT_6379_TCP_PORT || 6379,
     tokensPrefix: [unversionedApi, 'push-tokens'].join(':'),
     notificationsPrefix: [unversionedApi, 'push-notifications'].join(':'),
+
+    // When sending push notifications, sender cli will enqueue up to this
+    // number of Redis waiting notifications (RPOP it from redis and add
+    // to send queue).
+    cliReadAhead: 16,
+
+    // Apple related
     apn: {
       // connection
       cert: process.env.APN_CERT_FILEPATH ||
         path.join(__dirname, 'tests/push-api/cert.pem'),
       key: process.env.APN_KEY_FILEPATH ||
         path.join(__dirname, 'tests/push-api/key.pem'),
+      maxConnections: 2,
       // push messages
       defaultAlert: '\uD83D\uDCE7 \u2709 You have a new message',
       expiry: 3600,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "api": "notifications/v1",
   "description": "notifications micro service",
   "private": true,

--- a/src/push-api/sender-cli.coffee
+++ b/src/push-api/sender-cli.coffee
@@ -20,7 +20,8 @@ log = (require '../log').child(SenderCli:true)
 CONCURRENT_CONNECTIONS = 4
 
 debug = if !config.debug then () -> else () ->
-  log.debug.apply(log.debug, arguments)
+  # console.log.apply(console, arguments)
+  log.debug.apply(log, arguments)
 
 class Producer extends stream.Readable
   constructor: (@queue, concurrency=CONCURRENT_CONNECTIONS) ->

--- a/src/push-api/sender.coffee
+++ b/src/push-api/sender.coffee
@@ -14,12 +14,13 @@ class ApnSender
 
   # TODO
   # errors?
-  send: (notification, tokens) ->
+  send: (notification, tokens, callback=->) ->
     @log.info "send",
       tokens:tokens
       notification:notification
     devices = tokens.map (token) -> new apn.Device(token.data())
     @connection.pushNotification(notification, devices)
+    setImmediate(callback)
 
   close: () ->
     @connection.shutdown()
@@ -28,7 +29,7 @@ class Sender
   constructor: (@senders={}) ->
 
   # Sends push notification from task.notification for each one of task.tokens.
-  send: (task, callback) ->
+  send: (task, callback=->) ->
     # Group tokens by type
     groupedTokens = {}
     task.tokens.forEach (token) ->


### PR DESCRIPTION
> Should I expect to see some error logs if it failed?

I added some more logging in this PR for failed sends. It is delayed sometime and might not show up before process exits due to how `apn` works. (There seems to be no way to know whether notification was sent successfully and accepted.)

> Concurrency code states (`not sure if it works with APN atm`) (?)

When specifying `options.maxConnections` for `new apn.Connection`, I thought it would open multiple connections to Apple server, but it fires up `connected` event with only one. Should not be a problem, though, possibly it manages it internally and only adds more when 1 isn't enough.

> Is it possible that the process exits before the payload has been sent?

Seems like this was the case, should be fixed now.
