### PR TITLE
Fix crash on missing `*ArgsTypes`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "api": "notifications/v1",
   "description": "notifications micro service",
   "private": true,

--- a/src/push-api/push-translator.coffee
+++ b/src/push-api/push-translator.coffee
@@ -65,6 +65,10 @@ class PushTranslator
         types = @push["#{field}ArgsTypes"]
         translatables = []
 
+        # Some *ArgsTypes might be missing.
+        unless Array.isArray(types)
+          return
+
         for value, index in values
           type = types[index]
 

--- a/tests/push-api/test-push-translator.coffee
+++ b/tests/push-api/test-push-translator.coffee
@@ -1,4 +1,5 @@
 expect = require 'expect.js'
+lodash = require 'lodash'
 deepFreeze = require 'deep-freeze-strict'
 PushTranslator = require '../../src/push-api/push-translator'
 {PushObject, Translatable} = PushTranslator
@@ -31,6 +32,10 @@ describe 'PushTranslator', () ->
       it 'returns stuff to translate with proper indexes', () ->
         push = new PushObject(pushData)
         expect(push.translatables()).to.eql(expectedTranslatables)
+
+      it 'works when *ArgsTypes is missing for some fields', () ->
+        push = new PushObject(lodash.omit(pushData, 'messageArgsTypes'))
+        expect(push.translatables()).to.eql(expectedTranslatables.slice(0, 1))
 
     describe '#translatedUsing()', () ->
       it 'accepts a bunch of `Translation`s and returns translated push', () ->


### PR DESCRIPTION
`*ArgsTypes` are optional, account for that when looking for translatable pieces.
(Created `develop` branch as well.)

Also see https://github.com/j3k0/ganomede-notifications/pull/40#issuecomment-332542128.